### PR TITLE
Added github key property

### DIFF
--- a/resources/synapse_service.rb
+++ b/resources/synapse_service.rb
@@ -8,7 +8,7 @@ property :appservices, Array, default: []
 property :config, Hash, default: {}
 property :config_hookshot, Hash, default: {}
 property :domain, String, name_property: true
-property :key_github, String, default: nil
+property :key_github, String
 property :pg_host, String
 property :pg_name, String
 property :pg_username, String

--- a/resources/synapse_service.rb
+++ b/resources/synapse_service.rb
@@ -8,6 +8,7 @@ property :appservices, Array, default: []
 property :config, Hash, default: {}
 property :config_hookshot, Hash, default: {}
 property :domain, String, name_property: true
+property :key_github, String, default: nil
 property :pg_host, String
 property :pg_name, String
 property :pg_username, String
@@ -61,6 +62,7 @@ action :create do
     host_domain new_resource.domain
     config new_resource.config_hookshot
     tag new_resource.tag_hookshot
+    key_github new_resource.key_github
     only_if { new_resource.appservices.include?('hookshot') }
     notifies :rebuild, "osl_dockercompose[#{compose_unique}]"
   end


### PR DESCRIPTION
A quick patch to implement the automatic configuration and deployment of a Github secret key, in the event Github is needed for in Hookshot.