### PR TITLE
Added matrix-appservice-irc appservice resource

### DIFF
--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -1,6 +1,13 @@
 module OSLMatrix
   module Cookbook
     module Helpers
+      class ::Hash
+        def deep_merge(second)
+          merger = proc { |_key, v1, v2| v1.is_a?(Hash) && v2.is_a?(Hash) ? v1.merge(v2, &merger) : v2 }
+          merge(second, &merger)
+        end
+      end
+
       # Generate a secret key through hashing a string. Mainly used when wanting a registration key
       # WARNING: Not recommended for an actual deployment, only done when no secret is given.
       def osl_matrix_genkey(plain_text)
@@ -82,6 +89,70 @@ module OSLMatrix
             },
           }
         end
+      end
+
+      # Generate the default configuration for matrix-appservice-irc
+      def osl_matrix_irc_defaults(custom_config)
+        default_config = {
+          'homeserver' => {
+            'url' => 'http://synapse:8008',
+            'domain' => new_resource.host_domain,
+          },
+          'ircService' => {
+            'passwordEncryptionKeyPath' => '/data/passkey.pem',
+            'mediaProxy' => {
+              'signingKeyPath' => '/data/signingkey.jwk',
+              'ttlSeconds' => 3600,
+              'bindPort' => 11111,
+              'publicUrl' => 'http://irc-media-proxy-not-implemented.localhost',
+            },
+            'permissions' => {
+              new_resource.host_domain => 'admin',
+            },
+          },
+          'database' => {
+            'engine' => 'postgres',
+            'connectionString' => "postgres://postgres:#{osl_matrix_genkey(new_resource.container_name)}@#{new_resource.container_name}-postgres:5432/postgres",
+          },
+        }.deep_merge(custom_config)
+
+        # Loop over all IRC servers, adding their defaults.
+        begin
+          custom_config['ircService']['servers'].each do |server, server_config|
+            default_config['ircService']['servers'][server] = osl_matrix_irc_server_defaults(server_config)
+          end
+        rescue
+          # No servers given
+        end
+
+        # Do a final merge
+        osl_yaml_dump(default_config)
+      end
+
+      # Generate the default configuration for every IRC server
+      def osl_matrix_irc_server_defaults(custom_config)
+        {
+          'name' => 'Untitled IRC Server',
+          'botConfig' => {
+            'enabled' => true,
+            'username' => 'oslmatrixbot',
+          },
+          'dynamicChannels' => {
+            'enabled' => true,
+            'published' => false,
+          },
+          'matrixClients' => {
+            'userTemplate' => '@as-irc_$NICK',
+          },
+          'ircClients' => {
+            'nickTemplate' => '$DISPLAY[OSL-Matrix]',
+            'kickOn' => {
+              'channelJoinFailure' => true,
+              'ircConnectionFailure' => true,
+              'userQuit' => true,
+            },
+          },
+        }.deep_merge(custom_config)
       end
 
       # Get the name of the synapse docker container name, given the name of the synapse resource which creates it

--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -1,7 +1,6 @@
 module OSLMatrix
   module Cookbook
     module Helpers
-
       # Class function override for Hashes.
       # Traditional merge does not merge any child Hashes.
       # deep_merge allows for recursively merging child Hashes.

--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -1,6 +1,11 @@
 module OSLMatrix
   module Cookbook
     module Helpers
+
+      # Class function override for Hashes.
+      # Traditional merge does not merge any child Hashes.
+      # deep_merge allows for recursively merging child Hashes.
+      # Code taken from: https://stackoverflow.com/a/9381776
       class ::Hash
         def deep_merge(second)
           merger = proc { |_key, v1, v2| v1.is_a?(Hash) && v2.is_a?(Hash) ? v1.merge(v2, &merger) : v2 }

--- a/resources/matrix_irc.rb
+++ b/resources/matrix_irc.rb
@@ -1,0 +1,121 @@
+# osl_matrix_irc
+#
+# Matrix-Appservice-IRC is an IRC bouncer developed by Matrix.
+
+resource_name :osl_matrix_irc
+provides :osl_matrix_irc
+unified_mode true
+
+default_action :create
+
+property :container_name, String, name_property: true
+property :config, Hash, default: {}
+property :port, Integer, default: 8090
+property :host_domain, String, required: true
+property :host_name, String, default: lazy { "synapse-#{host_domain}" }
+property :host_path, String, default: lazy { "/opt/#{host_name}" }
+property :key_appservice, String, default: lazy { osl_matrix_genkey(host_name + container_name) }
+property :key_homeserver, String, default: lazy { osl_matrix_genkey(container_name + host_name) }
+property :tag, String, default: 'latest'
+property :sensitive, [true, false], default: true
+
+action :create do
+  # Pull down the latest version
+  docker_image 'matrixdotorg/matrix-appservice-irc' do
+    tag new_resource.tag
+  end
+
+  # Generate the app service file
+  osl_synapse_appservice(
+    'matrix-appservice-irc',
+    "http://#{new_resource.container_name}:#{new_resource.port}",
+    new_resource.key_appservice,
+    new_resource.key_homeserver,
+    'appservice-irc',
+    {
+      'users' => [
+        {
+          'exclusive' => true,
+          'regex' => '@as-irc_.*',
+        },
+      ],
+      'rate_limited' => false,
+      'protocols' => [
+        'irc',
+      ],
+    }
+  )
+
+  # Generate the config file
+  file "#{new_resource.host_path}/#{new_resource.container_name}-config.yaml" do
+    content osl_matrix_irc_defaults(new_resource.config)
+    owner 'synapse'
+    group 'synapse'
+    mode '400'
+    sensitive true
+  end
+
+  # Generate the passkey, one time
+  execute 'Generating Matrix-Appservice-IRC Passkey' do
+    command "openssl genpkey -out \"#{new_resource.host_path}/keys/irc-passkey.pem\" -outform PEM -algorithm RSA -pkeyopt rsa_keygen_bits:2048; chmod 400 '#{new_resource.host_path}/keys/irc-passkey.pem'"
+    user 'synapse'
+    group 'synapse'
+    creates "#{new_resource.host_path}/keys/irc-passkey.pem"
+  end
+
+  # Generate the signingkey, one time
+  # While we will NOT be using the media proxy, the bridge still requires this file.
+  # Using docker_container always throws a 400 HTTP error, executing docker works fine. Review requested.
+  # ---
+  #  docker_container 'Generate signingkey' do
+  #    repo 'matrixdotorg/matrix-appservice-irc'
+  #    autoremove true
+  #    volume "#{new_resource.host_path}/keys:/data"
+  #    entrypoint 'sh'
+  #    command ['-c', 'node lib/generate-signing-key.js > /data/signingkey.jwk && chmod 400 /data/signingkey.jwk']
+  #    user osl_synapse_user
+  #    not_if { ::File.exist?("#{new_resource.host_path}/keys/irc-signingkey.jwk") }
+  #  end
+  execute 'Generate signingkey' do
+    command "docker run --rm --entrypoint \"sh\" --volume #{new_resource.host_path}/keys:/data --user 994:989 matrixdotorg/matrix-appservice-irc \"-c\" \"node lib/generate-signing-key.js > /data/signingkey.jwk && chmod 400 /data/signingkey.jwk\""
+    creates "#{new_resource.host_path}/keys/signingkey.jwk"
+  end
+
+  # Generate the compose config
+  # Adding the PostgreSQL database as a container, instead of using an outside source, due to how little the DB needs to manage.
+  config_compose = {
+    'services' => {
+      "#{new_resource.container_name}-postgres" => {
+        'image' => 'postgres:16',
+        'volumes' => [
+          "#{new_resource.host_path}/appservice-data/#{new_resource.container_name}-postgres/:/var/lib/postgresql/data",
+        ],
+        'environment' => {
+          'POSTGRES_PASSWORD' => osl_matrix_genkey(new_resource.container_name),
+        },
+        'restart' => 'always',
+      },
+      new_resource.container_name => {
+        'image' => "matrixdotorg/matrix-appservice-irc:#{new_resource.tag}",
+        'volumes' => [
+          "#{new_resource.host_path}/appservice/#{new_resource.container_name}.yaml:/data/appservice-registration-irc.yaml",
+          "#{new_resource.host_path}/#{new_resource.container_name}-config.yaml:/data/config.yaml",
+          "#{new_resource.host_path}/keys/irc-passkey.pem:/data/passkey.pem",
+          "#{new_resource.host_path}/keys/signingkey.jwk:/data/signingkey.jwk",
+        ],
+        'user' => osl_synapse_user,
+        'restart' => 'always',
+        'depends_on' => ["#{new_resource.container_name}-postgres"],
+      },
+    },
+  }
+
+  # Generate compose file
+  file "#{new_resource.host_path}/compose/docker-#{new_resource.container_name}.yaml" do
+    content osl_yaml_dump(config_compose)
+    owner 'synapse'
+    group 'synapse'
+    mode '400'
+    sensitive true
+  end
+end

--- a/resources/synapse_service.rb
+++ b/resources/synapse_service.rb
@@ -7,6 +7,7 @@ default_action :create
 property :appservices, Array, default: []
 property :config, Hash, default: {}
 property :config_hookshot, Hash, default: {}
+property :config_matrix_irc, Hash, default: {}
 property :domain, String, name_property: true
 property :key_github, String
 property :pg_host, String
@@ -19,6 +20,7 @@ property :reg_key, String, default: lazy { osl_matrix_genkey(domain) }
 property :tag, String, default: 'latest'
 property :tag_heisenbridge, String, default: 'latest'
 property :tag_hookshot, String, default: 'latest'
+property :tag_matrix_irc, String, default: 'latest'
 property :sensitive, [true, false], default: true
 
 action :create do
@@ -64,6 +66,14 @@ action :create do
     tag new_resource.tag_hookshot
     key_github new_resource.key_github
     only_if { new_resource.appservices.include?('hookshot') }
+    notifies :rebuild, "osl_dockercompose[#{compose_unique}]"
+  end
+
+  osl_matrix_irc 'matrix-appservice-irc' do
+    host_domain new_resource.domain
+    config new_resource.config_matrix_irc
+    tag new_resource.tag_matrix_irc
+    only_if { new_resource.appservices.include?('matrix-appservice-irc') }
     notifies :rebuild, "osl_dockercompose[#{compose_unique}]"
   end
 end

--- a/spec/unit/resources/osl_synapse_spec.rb
+++ b/spec/unit/resources/osl_synapse_spec.rb
@@ -94,6 +94,7 @@ describe 'osl-matrix-test::synapse-no-quick' do
   }
 end
 
+# osl_hookshot
 describe 'osl-matrix-test::synapse-no-quick' do
   cached(:subject) { chef_run }
   platform 'almalinux', '8'
@@ -132,6 +133,60 @@ describe 'osl-matrix-test::synapse-no-quick' do
   # Create Hookshot compose file
   it {
     is_expected.to create_file('/opt/synapse-chat.example.org/compose/docker-osl-hookshot-webhook.yaml').with(
+      owner: 'synapse',
+      group: 'synapse',
+      mode: '400',
+      sensitive: true
+    )
+  }
+end
+
+# osl_matrix_irc
+describe 'osl-matrix-test::synapse-no-quick' do
+  cached(:subject) { chef_run }
+  platform 'almalinux', '8'
+  include_context 'pwnam'
+  step_into :osl_matrix_irc
+
+  # Appservice file
+  it {
+    is_expected.to create_file('/opt/synapse-chat.example.org/appservice/osl-matrix-irc.yaml').with(
+      owner: 'synapse',
+      group: 'synapse',
+      mode: '400',
+      sensitive: true
+    )
+  }
+
+  # Generate passkey file
+  it {
+    is_expected.to run_execute('Generating Matrix-Appservice-IRC Passkey').with(
+      command: "openssl genpkey -out \"/opt/synapse-chat.example.org/keys/irc-passkey.pem\" -outform PEM -algorithm RSA -pkeyopt rsa_keygen_bits:2048; chmod 400 '/opt/synapse-chat.example.org/keys/irc-passkey.pem'",
+      user: 'synapse',
+      group: 'synapse'
+    )
+  }
+
+  # Generate signing key file
+  it {
+    is_expected.to run_execute('Generate signingkey').with(
+      command: 'docker run --rm --entrypoint "sh" --volume /opt/synapse-chat.example.org/keys:/data --user 994:989 matrixdotorg/matrix-appservice-irc "-c" "node lib/generate-signing-key.js > /data/signingkey.jwk && chmod 400 /data/signingkey.jwk"'
+    )
+  }
+
+  # Generate config file
+  it {
+    is_expected.to create_file('/opt/synapse-chat.example.org/osl-matrix-irc-config.yaml').with(
+      owner: 'synapse',
+      group: 'synapse',
+      mode: '400',
+      sensitive: true
+    )
+  }
+
+  # Create matrix-appservice-irc compose file
+  it {
+    is_expected.to create_file('/opt/synapse-chat.example.org/compose/docker-osl-matrix-irc.yaml').with(
       owner: 'synapse',
       group: 'synapse',
       mode: '400',

--- a/test/cookbooks/osl-matrix-test/recipes/synapse.rb
+++ b/test/cookbooks/osl-matrix-test/recipes/synapse.rb
@@ -1,6 +1,6 @@
 # Create a quick synapse server
 osl_synapse_service 'chat.example.org' do
-  appservices %w(hookshot heisenbridge)
+  appservices %w(hookshot heisenbridge matrix-appservice-irc)
   reg_key 'this-is-my-secret'
   config(
     {
@@ -31,4 +31,11 @@ osl_synapse_service 'chat.example.org' do
       },
     }
   )
+  config_matrix_irc({
+    'ircService' => {
+      'servers' => {
+        'ircd' => {},
+      },
+    },
+  })
 end

--- a/test/integration/synapse-ala-carte/inspec/synapse_spec.rb
+++ b/test/integration/synapse-ala-carte/inspec/synapse_spec.rb
@@ -97,3 +97,46 @@ describe docker_container('synapse-osl-hookshot-webhook-1') do
   its('image') { should eq 'halfshot/matrix-hookshot:latest' }
   its('ports') { should match '9000-9002->9000-9002/tcp' }
 end
+
+# Matrix-Appservice-IRC Appservice
+
+# Matrix-IRC Appservice Configuration
+describe file('/opt/synapse-chat.example.org/appservice/osl-matrix-irc.yaml') do
+  it { should exist }
+  its('owner') { should eq 'synapse' }
+  its('content') { should match 'id: matrix-appservice-irc' }
+  its('content') { should match 'url: http://osl-matrix-irc:8090' }
+end
+
+# Docker Container
+describe docker_container('synapse-osl-matrix-irc-1') do
+  it { should exist }
+  it { should be_running }
+  its('image') { should eq 'matrixdotorg/matrix-appservice-irc:latest' }
+end
+
+# Config File
+describe file('/opt/synapse-chat.example.org/osl-matrix-irc-config.yaml') do
+  it { should exist }
+  its('owner') { should eq 'synapse' }
+  its('mode') { should cmp '0400' }
+end
+
+# IRC key
+describe file('/opt/synapse-chat.example.org/keys/irc-passkey.pem') do
+  it { should exist }
+  its('owner') { should eq 'synapse' }
+  its('mode') { should cmp '0400' }
+end
+
+# Media signing key
+describe file('/opt/synapse-chat.example.org/keys/signingkey.jwk') do
+  it { should exist }
+  its('owner') { should eq 'synapse' }
+  its('mode') { should cmp '0400' }
+end
+
+# Postgres data directory
+describe file('/opt/synapse-chat.example.org/appservice-data/osl-matrix-irc-postgres/postgresql.conf') do
+  it { should exist }
+end

--- a/test/integration/synapse/inspec/synapse_spec.rb
+++ b/test/integration/synapse/inspec/synapse_spec.rb
@@ -97,3 +97,46 @@ describe docker_container('e5af17-hookshot-1') do
   its('image') { should eq 'halfshot/matrix-hookshot:latest' }
   its('ports') { should match '9000-9002->9000-9002/tcp' }
 end
+
+# Matrix-Appservice-IRC Appservice
+
+# Matrix-IRC Appservice Configuration
+describe file('/opt/synapse-chat.example.org/appservice/matrix-appservice-irc.yaml') do
+  it { should exist }
+  its('owner') { should eq 'synapse' }
+  its('content') { should match 'id: matrix-appservice-irc' }
+  its('content') { should match 'url: http://matrix-appservice-irc:8090' }
+end
+
+# Docker Container
+describe docker_container('e5af17-matrix-appservice-irc-1') do
+  it { should exist }
+  it { should be_running }
+  its('image') { should eq 'matrixdotorg/matrix-appservice-irc:latest' }
+end
+
+# Config File
+describe file('/opt/synapse-chat.example.org/matrix-appservice-irc-config.yaml') do
+  it { should exist }
+  its('owner') { should eq 'synapse' }
+  its('mode') { should cmp '0400' }
+end
+
+# IRC key
+describe file('/opt/synapse-chat.example.org/keys/irc-passkey.pem') do
+  it { should exist }
+  its('owner') { should eq 'synapse' }
+  its('mode') { should cmp '0400' }
+end
+
+# Media signing key
+describe file('/opt/synapse-chat.example.org/keys/signingkey.jwk') do
+  it { should exist }
+  its('owner') { should eq 'synapse' }
+  its('mode') { should cmp '0400' }
+end
+
+# Postgres data directory
+describe file('/opt/synapse-chat.example.org/appservice-data/matrix-appservice-irc-postgres/postgresql.conf') do
+  it { should exist }
+end


### PR DESCRIPTION
[matrix-appservice-irc](https://github.com/matrix-org/matrix-appservice-irc/tree/develop) is an appservice made by Matrix designed to bridge IRC. In the same way as our current Heisenbridge setup, but this appservice runs multiple IRC connections, per-user, talking from Matrix onto the IRC side.

Our plan is to add this to our current Matrix instance, and only allow it for private use. `osl-nodes` PR in the works.