### PR TITLE
Emergency Patch for matrix-appservice-irc

### DIFF
--- a/resources/matrix_irc.rb
+++ b/resources/matrix_irc.rb
@@ -77,7 +77,7 @@ action :create do
   #    not_if { ::File.exist?("#{new_resource.host_path}/keys/irc-signingkey.jwk") }
   #  end
   execute 'Generate signingkey' do
-    command "docker run --rm --entrypoint \"sh\" --volume #{new_resource.host_path}/keys:/data --user 994:989 matrixdotorg/matrix-appservice-irc \"-c\" \"node lib/generate-signing-key.js > /data/signingkey.jwk && chmod 400 /data/signingkey.jwk\""
+    command "docker run --rm --entrypoint \"sh\" --volume #{new_resource.host_path}/keys:/data --user #{osl_synapse_user} matrixdotorg/matrix-appservice-irc \"-c\" \"node lib/generate-signing-key.js > /data/signingkey.jwk && chmod 400 /data/signingkey.jwk\""
     creates "#{new_resource.host_path}/keys/signingkey.jwk"
   end
 

--- a/spec/unit/resources/osl_synapse_spec.rb
+++ b/spec/unit/resources/osl_synapse_spec.rb
@@ -170,7 +170,7 @@ describe 'osl-matrix-test::synapse-no-quick' do
   # Generate signing key file
   it {
     is_expected.to run_execute('Generate signingkey').with(
-      command: 'docker run --rm --entrypoint "sh" --volume /opt/synapse-chat.example.org/keys:/data --user 994:989 matrixdotorg/matrix-appservice-irc "-c" "node lib/generate-signing-key.js > /data/signingkey.jwk && chmod 400 /data/signingkey.jwk"'
+      command: 'docker run --rm --entrypoint "sh" --volume /opt/synapse-chat.example.org/keys:/data --user 1001: matrixdotorg/matrix-appservice-irc "-c" "node lib/generate-signing-key.js > /data/signingkey.jwk && chmod 400 /data/signingkey.jwk"'
     )
   }
 


### PR DESCRIPTION
There was a hardcoded argument of a UID and GID, which is not consistent in production.