### PR TITLE
Add Mjolnir as an Appservice

### DIFF
--- a/documentation/osl_mjolnir.md
+++ b/documentation/osl_mjolnir.md
@@ -1,0 +1,45 @@
+# osl\_mjolnir
+
+A Matrix auto-moderation appservice developed by the Matrix foundation.
+
+[Mjolnir Documentation](https://github.com/matrix-org/mjolnir/blob/main/docs/setup.md)
+
+**IMPORTANT**:
+* Appservice resources should only be called *after* deploying the Matrix Synapse Server.
+* This resource will not deploy, by itself. It requires an [`osl_dockercompose`](https://github.com/osuosl-cookbooks/osl-docker/blob/master/resources/dockercompose.rb) resource.
+* This appservice **does not run by default**. It requires the creation of a channel, dictated by `default_channel`. Defaults to `#mjolnir`.
+
+## Actions
+
+| Action   | Description         |
+| -------- | ------------------- |
+| `create` | Deploy Mjolnir      |
+
+## Properties
+
+| Name             | Type    | Default                                       | Description | Required |
+| ---------------- | ------- | --------------------------------------------- | ----------- | -------- |
+| `config`         | Hash    |                                               | A grainular application to Mjolnir settings. A lot of other required configurations have been automated. Information of arguments can be found in the [Mjolnir Example](https://github.com/matrix-org/mjolnir/blob/main/src/appservice/config/config.example.yaml) | |
+| `container_name` | String  |                                               | The name of the Docker container running Mjolnir. Use this name for specifiying the appservices available on a `osl_synapse` service | Yes, name property |
+| `port`           | Integer | `9899`                                        | The port used for internal listening from requests from the Matrix Synapse server | |
+| `port_api`       | Integer | `9004`                                        | **IMPORTANT, SECURITY** The port open on the host machine which listens for specific Matrix protocol HTTP requests. More information can be found in the [Mjolnir Documentation](https://github.com/matrix-org/mjolnir/blob/main/README.md#enabling-readable-abuse-reports). It's required to put this behind a reverse proxy | |
+| `host_domain`    | String  |                                               | The resource name of the Matrix Synapse Server Mjolnir will be providing for | Yes |
+| `host_name`      | String  | `matrix-synapse-{host_domain}`                | The name of the Docker container containing the Matrix Synapse server | |
+| `host_path`      | String  | `/opt/synapse-{host_name}`                    | The path to the configuration files of the Matrix Synapse server  | |
+| `key_appservice` | String  | `MD5 hash of host_name and container_name`    | **IMPORTANT, SECURITY** A string token that the appservices uses to authenticate requests to the homeserver. Please change out with a databag entry | Encouraged |
+| `key_homeserver` | String  | `MD5 hash of host_network and container_name` | **IMPORTANT, SECURITY** A string token that the homesever uses to authenticate requests to the appservice. Please change out with a databag entry | Encouraged |
+| `bot_name`       | String  | `Auto Mod`                                    | The fancy name of the bot | |
+| `default_channel`| String  | `#mjolnir:{host_domain}`                      | The initial channel that Mjolnir connects to. The channel can be made private, after the bot connects. | |
+| `tag`            | String  | `latest`                                      | The Mjolnir version to deploy. Please view the [Docker Hub](https://hub.docker.com/r/matrixdotorg/mjolnir) for valid entries. | |
+
+## Examples
+```ruby
+# Deploy Mjolnir onto chat.example.org
+osl_synapse 'chat.example.org' do
+  appservices: %w(example-mod)
+end
+
+osl_mjolnir 'example-mod' do
+  host_domain 'chat.example.org'
+end
+```

--- a/documentation/osl_synapse_service.md
+++ b/documentation/osl_synapse_service.md
@@ -18,6 +18,8 @@ Any missing properties with the `pg_` prefix will result in the server setting u
 | -------------- | --------------------------------------------------------------------------- |
 | `heisenbridge` | An IRC bridge for Matrix [\[Github\]](https://github.com/hifi/heisenbridge) |
 | `hookshot`     | A webhook bot for recieving alerts [\[Github\]](https://github.com/matrix-org/matrix-hookshot) |
+| `matrix-appservice-irc` | A more feature rich IRC bridge for Matrix [\[Github\]](https://github.com/matrix-org/matrix-appservice-irc) |
+| `mjolnir`      | An auto-moderation bot for Matris [\[Github\]](https://github.com/matrix-org/mjolnir) |
 
 ## Properties
 
@@ -25,7 +27,8 @@ Any missing properties with the `pg_` prefix will result in the server setting u
 | ---------------- | ---------------- | ------------------------------------------------ | ----------- | -------- |
 | `appservices`    | Array            | `[]`                                             | An array of appservices which will be tied to this application. **Provide the resource name of the appservice**. | |
 | `config`         | Hash             | `{}`                                             | General Matrix Synapse settings to apply. Information of arguments can be found in the [Synapse Documentation](https://matrix-org.github.io/synapse/latest/usage/configuration/config_documentation.html) | |
-| `config_hookshot`| Hash    |                                               | General Matrix Hookshot settings to apply, mostly going to be used to set up specific services and configuration permissions. A lot of other required configurations have been automated. Information of arguments can be found in the [Hookshot Documentation](https://matrix-org.github.io/matrix-hookshot/latest/setup/sample-configuration.html) | |
+| `config_hookshot`| Hash             |                                                  | General Matrix Hookshot settings to apply, mostly going to be used to set up specific services and configuration permissions. A lot of other required configurations have been automated. Information of arguments can be found in the [Hookshot Documentation](https://matrix-org.github.io/matrix-hookshot/latest/setup/sample-configuration.html) | |
+| `config_mjolnir` | Hash             |                                                  | A grainular application to Mjolnir settings. A lot of other required configurations have been automated. Information of arguments can be found in the [Mjolnir Example](https://github.com/matrix-org/mjolnir/blob/main/src/appservice/config/config.example.yaml) | |
 | `domain`         | String           |                                                  | The FQDN of the matrix synapse site | Yes, resource name |
 | `pg_host`        | String           |                                                  | IP/Hostname of the Postgresql server | |
 | `pg_name`        | String           |                                                  | Database name | |

--- a/files/default/mjolnir_init.sql
+++ b/files/default/mjolnir_init.sql
@@ -1,0 +1,2 @@
+\c moderator
+CREATE TABLE mjolnir (local_part VARCHAR(255), owner VARCHAR(255), management_room TEXT);

--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -95,6 +95,27 @@ module OSLMatrix
         end
       end
 
+      # Generate the default configuraiton for Mjonir
+      def osl_mjolnir_defaults(custom_config)
+        {
+          'homeserver' => {
+            'domain' => "#{new_resource.host_domain}",
+            'url' => 'http://synapse:8008',
+          },
+          'db' => {
+            'engine' => 'postgres',
+            'connectionString' => "postgres://moderator:#{new_resource.key_homeserver}@#{new_resource.container_name}-db/moderator",
+          },
+          'webAPI' => {
+            'port' => new_resource.port_api,
+          },
+          'bot' => {
+            'displayName' => new_resource.bot_name,
+          },
+          'accessControlList' => new_resource.default_channel,
+        }.deep_merge(custom_config)
+      end
+
       # Generate the default configuration for matrix-appservice-irc
       def osl_matrix_irc_defaults(custom_config)
         default_config = {

--- a/resources/mjolnir.rb
+++ b/resources/mjolnir.rb
@@ -73,7 +73,7 @@ action :create do
           'POSTGRES_USER' => 'moderator',
         },
         'volumes' => [
-          "#{new_resource.host_path}/appservice-data/mjolnir.sql:/docker-entrypoint-initdb.d/init.sql:ro",
+          "#{new_resource.host_path}/appservice-data/mjolnir_init.sql:/docker-entrypoint-initdb.d/init.sql:ro",
           "#{new_resource.host_path}/appservice-data/#{new_resource.container_name}-db:/var/lib/postgresql/data",
         ],
       },
@@ -81,8 +81,9 @@ action :create do
   }
 
   # Generate the initSQL file
-  file "#{new_resource.host_path}/appservice-data/mjolnir.sql" do
-    content "\\c moderator\n CREATE TABLE mjolnir (local_part VARCHAR(255), owner VARCHAR(255), management_room TEXT);"
+  cookbook_file "#{new_resource.host_path}/appservice-data/mjolnir_init.sql" do
+    source 'mjolnir_init.sql'
+    cookbook 'osl-matrix'
   end
 
   # Generate the config file

--- a/resources/mjolnir.rb
+++ b/resources/mjolnir.rb
@@ -1,0 +1,105 @@
+# osl_mjolnir
+#
+# Mjolnir is a moderation bot for use in Matrix Synapse
+# https://github.com/matrix-org/mjolnir
+
+resource_name :osl_mjolnir
+provides :osl_mjolnir
+unified_mode true
+
+default_action :create
+
+property :config, Hash, default: {}
+property :container_name, String, name_property: true
+property :port, Integer, default: 9899
+property :port_api, Integer, default: 9003
+property :host_domain, String, required: true
+property :host_name, String, default: lazy { "synapse-#{host_domain}" }
+property :host_path, String, default: lazy { "/opt/#{host_name}" }
+property :key_appservice, String, default: lazy { osl_matrix_genkey(host_name + container_name) }
+property :key_homeserver, String, default: lazy { osl_matrix_genkey(container_name + host_name) }
+property :bot_name, String, default: 'Auto Mod'
+property :default_channel, String, default: lazy { "#mjolnir:#{host_domain}" }
+property :tag, String, default: 'latest'
+property :sensitive, [true, false], default: true
+
+action :create do
+  # Pull down the latest version
+  docker_image 'matrixdotorg/mjolnir' do
+    tag new_resource.tag
+  end
+
+  # Get the config from the new resource, and put into a mutable variable
+  config = osl_mjolnir_defaults(new_resource.config)
+
+  # Generate the app service file
+  osl_synapse_appservice(
+    'mjolnir',
+    "http://#{new_resource.container_name}:#{new_resource.port}",
+    new_resource.key_appservice,
+    new_resource.key_homeserver,
+    'mjolnir',
+    {
+      'users' => [
+        {
+          'exclusive' => true,
+          'regex' => '@mjolnir_.*',
+        },
+      ],
+    }
+  )
+
+  # Generate the compose config
+  config_compose = {
+    'services' => {
+      new_resource.container_name => {
+        'command' => "appservice -c /data/config.yaml -f /data/appservice.yaml -p #{new_resource.port}",
+        'image' => "matrixdotorg/mjolnir:#{new_resource.tag}",
+        'volumes' => [
+          "#{new_resource.host_path}/appservice/#{new_resource.container_name}.yaml:/data/appservice.yaml:ro",
+          "#{new_resource.host_path}/#{new_resource.container_name}-config.yaml:/data/config.yaml:ro",
+          "#{new_resource.host_path}/appservice-data/#{new_resource.container_name}:/data/persistent",
+        ],
+        'ports' => [
+          "#{new_resource.port_api}:#{new_resource.port_api}",
+        ],
+        'restart' => 'always',
+        'depends_on' => ["#{new_resource.container_name}-db"],
+      },
+      "#{new_resource.container_name}-db" => {
+        'image' => 'postgres',
+        'environment' => {
+          'POSTGRES_PASSWORD' => new_resource.key_homeserver,
+          'POSTGRES_USER' => 'moderator',
+        },
+        'volumes' => [
+          "#{new_resource.host_path}/appservice-data/mjolnir.sql:/docker-entrypoint-initdb.d/init.sql:ro",
+          "#{new_resource.host_path}/appservice-data/#{new_resource.container_name}-db:/var/lib/postgresql/data",
+        ],
+      },
+    },
+  }
+
+  # Generate the initSQL file
+  file "#{new_resource.host_path}/appservice-data/mjolnir.sql" do
+    content "\\c moderator\n CREATE TABLE mjolnir (local_part VARCHAR(255), owner VARCHAR(255), management_room TEXT);"
+  end
+
+  # Generate the config file
+  file "#{new_resource.host_path}/#{new_resource.container_name}-config.yaml" do
+    content osl_yaml_dump(config)
+    owner 'synapse'
+    group 'synapse'
+    mode '400'
+    sensitive true
+  end
+
+  # Generate compose file
+  file "#{new_resource.host_path}/compose/docker-#{new_resource.container_name}.yaml" do
+    content osl_yaml_dump(config_compose)
+    owner 'synapse'
+    group 'synapse'
+    mode '400'
+    sensitive true
+  end
+end

--- a/resources/synapse.rb
+++ b/resources/synapse.rb
@@ -53,7 +53,7 @@ action :create do
   end
 
   # Keys, Compose, and appservice file directories
-  %w(keys compose appservice).each do |dir|
+  %w(keys compose appservice appservice-data).each do |dir|
     directory "#{new_resource.path}/#{dir}" do
       owner 'synapse'
       mode '700'

--- a/resources/synapse_service.rb
+++ b/resources/synapse_service.rb
@@ -89,7 +89,7 @@ action :create do
     host_domain new_resource.domain
     config new_resource.config_mjolnir
     tag new_resource.tag_mjolnir
-    only_if { new_resource.appservices.include?('matrix-appservice-irc') }
+    only_if { new_resource.appservices.include?('mjolnir') }
     notifies :rebuild, "osl_dockercompose[#{compose_unique}]"
     notifies :restart, "osl_dockercompose[#{compose_unique}]"
   end

--- a/resources/synapse_service.rb
+++ b/resources/synapse_service.rb
@@ -8,6 +8,7 @@ property :appservices, Array, default: []
 property :config, Hash, default: {}
 property :config_hookshot, Hash, default: {}
 property :config_matrix_irc, Hash, default: {}
+property :config_mjolnir, Hash, default: {}
 property :domain, String, name_property: true
 property :irc_users_regex, String, default: '@as-irc_.*'
 property :key_github, String
@@ -22,6 +23,7 @@ property :tag, String, default: 'latest'
 property :tag_heisenbridge, String, default: 'latest'
 property :tag_hookshot, String, default: 'latest'
 property :tag_matrix_irc, String, default: 'latest'
+property :tag_mjolnir, String, default: 'latest'
 property :sensitive, [true, false], default: true
 
 action :create do
@@ -78,6 +80,15 @@ action :create do
     config new_resource.config_matrix_irc
     tag new_resource.tag_matrix_irc
     users_regex new_resource.irc_users_regex
+    only_if { new_resource.appservices.include?('matrix-appservice-irc') }
+    notifies :rebuild, "osl_dockercompose[#{compose_unique}]"
+    notifies :restart, "osl_dockercompose[#{compose_unique}]"
+  end
+
+  osl_mjolnir 'mjolnir' do
+    host_domain new_resource.domain
+    config new_resource.config_mjolnir
+    tag new_resource.tag_mjolnir
     only_if { new_resource.appservices.include?('matrix-appservice-irc') }
     notifies :rebuild, "osl_dockercompose[#{compose_unique}]"
     notifies :restart, "osl_dockercompose[#{compose_unique}]"

--- a/spec/unit/resources/osl_synapse_spec.rb
+++ b/spec/unit/resources/osl_synapse_spec.rb
@@ -210,3 +210,45 @@ describe 'osl-matrix-test::synapse-no-quick' do
     end
   end
 end
+
+# osl_mjolnir
+describe 'osl-matrix-test::synapse-no-quick' do
+  ALL_PLATFORMS.each do |p|
+    context "#{p[:platform]} #{p[:version]}" do
+      cached(:chef_run) do
+        ChefSpec::SoloRunner.new(p.merge({ step_into: :osl_mjolnir })).converge(described_recipe)
+      end
+      include_context 'pwnam'
+
+      # Appservice file
+      it do
+        is_expected.to create_file('/opt/synapse-chat.example.org/appservice/osl-moderate.yaml').with(
+          owner: 'synapse',
+          group: 'synapse',
+          mode: '400',
+          sensitive: true
+        )
+      end
+
+      # Generate config file
+      it do
+        is_expected.to create_file('/opt/synapse-chat.example.org/osl-moderate-config.yaml').with(
+          owner: 'synapse',
+          group: 'synapse',
+          mode: '400',
+          sensitive: true
+        )
+      end
+
+      # Create Hookshot compose file
+      it do
+        is_expected.to create_file('/opt/synapse-chat.example.org/compose/docker-osl-moderate.yaml').with(
+          owner: 'synapse',
+          group: 'synapse',
+          mode: '400',
+          sensitive: true
+        )
+      end
+    end
+  end
+end

--- a/test/cookbooks/osl-matrix-test/recipes/synapse-no-quick.rb
+++ b/test/cookbooks/osl-matrix-test/recipes/synapse-no-quick.rb
@@ -2,7 +2,7 @@ include_recipe 'osl-docker'
 
 # Create the synapse docker container
 osl_synapse 'chat.example.org' do
-  appservices %w(osl-irc-bridge osl-hookshot-webhook osl-matrix-irc)
+  appservices %w(osl-irc-bridge osl-hookshot-webhook osl-matrix-irc osl-moderate)
   reg_key 'this-is-my-secret'
   pg_host 'postgres'
   pg_name 'synapse'
@@ -31,6 +31,11 @@ osl_synapse 'chat.example.org' do
   sensitive false
 end
 
+# Mjolnir moderation
+osl_mjolnir 'osl-moderate' do
+  host_domain 'chat.example.org'
+end
+
 # Matrix-Appservice-IRC App Service
 osl_matrix_irc 'osl-matrix-irc' do
   host_domain 'chat.example.org'
@@ -41,7 +46,6 @@ osl_matrix_irc 'osl-matrix-irc' do
       },
     },
   })
-  sensitive false
 end
 
 # Add on the Heisenbridge app service
@@ -71,7 +75,7 @@ osl_hookshot 'osl-hookshot-webhook' do
     },
   })
 end
-
+#
 # Additional servers for testing
 file '/opt/synapse-chat.example.org/compose/docker-addons.yaml' do
   content osl_yaml_dump({
@@ -97,5 +101,5 @@ end
 # Run the docker compose
 osl_dockercompose 'synapse' do
   directory '/opt/synapse-chat.example.org/compose'
-  config %w(docker-addons.yaml docker-synapse.yaml docker-osl-irc-bridge.yaml docker-osl-hookshot-webhook.yaml docker-osl-matrix-irc.yaml)
+  config %w(docker-addons.yaml docker-synapse.yaml docker-osl-irc-bridge.yaml docker-osl-hookshot-webhook.yaml docker-osl-matrix-irc.yaml docker-osl-moderate.yaml)
 end

--- a/test/cookbooks/osl-matrix-test/recipes/synapse.rb
+++ b/test/cookbooks/osl-matrix-test/recipes/synapse.rb
@@ -1,6 +1,6 @@
 # Create a quick synapse server
 osl_synapse_service 'chat.example.org' do
-  appservices %w(hookshot heisenbridge matrix-appservice-irc)
+  appservices %w(hookshot heisenbridge matrix-appservice-irc mjolnir)
   reg_key 'this-is-my-secret'
   config(
     {

--- a/test/integration/synapse-ala-carte/inspec/synapse_spec.rb
+++ b/test/integration/synapse-ala-carte/inspec/synapse_spec.rb
@@ -140,3 +140,37 @@ end
 describe file('/opt/synapse-chat.example.org/appservice-data/osl-matrix-irc-postgres/postgresql.conf') do
   it { should exist }
 end
+
+# Mjolnir Appservice
+
+# Hookshot Appservice Configuration
+describe file('/opt/synapse-chat.example.org/appservice/osl-moderate.yaml') do
+  it { should exist }
+  its('owner') { should eq 'synapse' }
+  its('content') { should match 'id: mjolnir' }
+  its('content') { should match 'url: http://osl-moderate:9899' }
+end
+
+describe file('/opt/synapse-chat.example.org/osl-moderate-config.yaml') do
+  it { should exist }
+  its('owner') { should eq 'synapse' }
+end
+
+# Postgres data directory
+describe file('/opt/synapse-chat.example.org/appservice-data/osl-moderate-db/postgresql.conf') do
+  it { should exist }
+end
+
+# Main Docker Container
+# Should not be running, as there is a default failing state.
+describe docker_container('synapse-osl-moderate-1') do
+  it { should exist }
+  its('image') { should eq 'matrixdotorg/mjolnir:latest' }
+end
+
+# Database Docker Container
+describe docker_container('synapse-osl-moderate-db-1') do
+  it { should exist }
+  it { should be_running }
+  its('image') { should eq 'postgres' }
+end

--- a/test/integration/synapse/inspec/synapse_spec.rb
+++ b/test/integration/synapse/inspec/synapse_spec.rb
@@ -140,3 +140,37 @@ end
 describe file('/opt/synapse-chat.example.org/appservice-data/matrix-appservice-irc-postgres/postgresql.conf') do
   it { should exist }
 end
+
+# Mjolnir Appservice
+
+# Hookshot Appservice Configuration
+describe file('/opt/synapse-chat.example.org/appservice/mjolnir.yaml') do
+  it { should exist }
+  its('owner') { should eq 'synapse' }
+  its('content') { should match 'id: mjolnir' }
+  its('content') { should match 'url: http://mjolnir:9899' }
+end
+
+describe file('/opt/synapse-chat.example.org/mjolnir-config.yaml') do
+  it { should exist }
+  its('owner') { should eq 'synapse' }
+end
+
+# Postgres data directory
+describe file('/opt/synapse-chat.example.org/appservice-data/mjolnir-db/postgresql.conf') do
+  it { should exist }
+end
+
+# Main Docker Container
+# Should not be running, as there is a default failing state.
+describe docker_container('e5af17-mjolnir-1') do
+  it { should exist }
+  its('image') { should eq 'matrixdotorg/mjolnir:latest' }
+end
+
+# Database Docker Container
+describe docker_container('e5af17-mjolnir-db-1') do
+  it { should exist }
+  it { should be_running }
+  its('image') { should eq 'postgres' }
+end


### PR DESCRIPTION
[Mjolnir](https://github.com/matrix-org/mjolnir) is an automated moderation bot made by Matrix. This addition implements in the [appservice version of the bot](https://github.com/matrix-org/mjolnir/blob/main/docs/appservice.md).

The appservice is normally deployed in a non-running state, as it requires a user to create a public channel `#mjolnir:[DOMAIN]` in order to complete installation.

The PR is functional, to allow for review, but I'd like to append to the documentation before merging.