### PR TITLE
Add missing notifies when config changes

### DIFF
--- a/Berksfile
+++ b/Berksfile
@@ -1,16 +1,7 @@
+source 'https://supermarket.osuosl.org'
 source 'https://supermarket.chef.io'
 
 solver :ruby, :required
-
-cookbook 'osl-docker', git: 'git@github.com:osuosl-cookbooks/osl-docker'
-cookbook 'osl-firewall', git: 'git@github.com:osuosl-cookbooks/osl-firewall'
-cookbook 'osl-gpu', git: 'git@github.com:osuosl-cookbooks/osl-gpu', branch: 'main'
-cookbook 'osl-postgresql', git: 'git@github.com:osuosl-cookbooks/osl-postgresql'
-cookbook 'osl-nginx', git: 'git@github.com:osuosl-cookbooks/osl-nginx'
-cookbook 'osl-nrpe', git: 'git@github.com:osuosl-cookbooks/osl-nrpe'
-cookbook 'osl-repos', git: 'git@github.com:osuosl-cookbooks/osl-repos'
-cookbook 'osl-resources', git: 'git@github.com:osuosl-cookbooks/osl-resources', branch: 'main'
-cookbook 'osl-selinux', git: 'git@github.com:osuosl-cookbooks/osl-selinux'
 
 cookbook 'osl-matrix-test', path: 'test/cookbooks/osl-matrix-test/'
 

--- a/resources/element.rb
+++ b/resources/element.rb
@@ -22,6 +22,7 @@ action :create do
     cookbook 'osl-matrix'
     variables(fqdn: new_resource.matrix_domain)
     sensitive true
+    notifies :redeploy, 'docker_container[element_webapp]'
   end
 
   docker_image 'vectorim/element-web' do

--- a/resources/synapse_admin.rb
+++ b/resources/synapse_admin.rb
@@ -22,6 +22,7 @@ action :create do
   file "/opt/synapse_admin_#{new_resource.container_name}/config.json" do
     content JSON.dump({ 'restrictBaseUrl' => new_resource.home_server })
     not_if { new_resource.home_server.empty? }
+    notifies :redeploy, "docker_container[#{new_resource.container_name}]"
   end
 
   docker_image 'awesometechnologies/synapse-admin' do

--- a/spec/unit/resources/osl_element_spec.rb
+++ b/spec/unit/resources/osl_element_spec.rb
@@ -15,18 +15,19 @@ describe 'osl-matrix-test::element' do
       end
 
       it { is_expected.to create_directory('/opt/element') }
+      it { is_expected.to create_template('/opt/element/config.json').with(source: 'element-config.json.erb') }
 
       it do
-        is_expected.to create_template('/opt/element/config.json').with(
-          source: 'element-config.json.erb'
-        )
+        expect(chef_run.template('/opt/element/config.json')).to \
+          notify('docker_container[element_webapp]').to(:redeploy)
       end
 
-      it {
-        is_expected.to pull_docker_image('vectorim/element-web').with(
-          tag: 'latest'
-        )
-      }
+      it { is_expected.to pull_docker_image('vectorim/element-web').with(tag: 'latest') }
+
+      it do
+        expect(chef_run.docker_image('vectorim/element-web')).to \
+          notify('docker_container[element_webapp]').to(:redeploy).immediately
+      end
 
       it do
         is_expected.to run_docker_container('element_webapp').with(

--- a/spec/unit/resources/osl_synapse_admin_spec.rb
+++ b/spec/unit/resources/osl_synapse_admin_spec.rb
@@ -23,7 +23,17 @@ describe 'osl-matrix-test::synapse-admin' do
         )
       end
 
+      it do
+        expect(chef_run.file('/opt/synapse_admin_test_admin/config.json')).to \
+          notify('docker_container[test_admin]').to(:redeploy)
+      end
+
       it { is_expected.to pull_docker_image('awesometechnologies/synapse-admin') }
+
+      it do
+        expect(chef_run.docker_image('awesometechnologies/synapse-admin')).to \
+          notify('docker_container[test_admin]').to(:redeploy)
+      end
 
       it do
         is_expected.to run_docker_container('test_admin').with(
@@ -41,7 +51,17 @@ describe 'osl-matrix-test::synapse-admin' do
         )
       end
 
+      it do
+        expect(chef_run.file('/opt/synapse_admin_test_multiple_servers/config.json')).to \
+          notify('docker_container[test_multiple_servers]').to(:redeploy)
+      end
+
       it { is_expected.to pull_docker_image('awesometechnologies/synapse-admin') }
+
+      it do
+        expect(chef_run.docker_image('awesometechnologies/synapse-admin')).to \
+          notify('docker_container[test_multiple_servers]').to(:redeploy)
+      end
 
       it do
         is_expected.to run_docker_container('test_multiple_servers').with(


### PR DESCRIPTION
Add redeploy notifications for the osl_element and osl_synapse_admin resources
if the config changes. As it stands now, it doesn't rebuild the container so the
config doesn't get deployed.

In addition, migrate to using our private supermarket in Berksfile.

Signed-off-by: Lance Albertson <lance@osuosl.org>
