### PR TITLE
Add docker compose helper script

### DIFF
--- a/resources/synapse_service.rb
+++ b/resources/synapse_service.rb
@@ -93,4 +93,17 @@ action :create do
     notifies :rebuild, "osl_dockercompose[#{compose_unique}]"
     notifies :restart, "osl_dockercompose[#{compose_unique}]"
   end
+
+  directory "#{synapse_path}/bin"
+
+  template "#{synapse_path}/bin/docker_compose" do
+    source 'docker_compose.erb'
+    cookbook 'osl-matrix'
+    mode '0755'
+    variables(
+      directory: "#{synapse_path}/compose",
+      project: compose_unique,
+      config_files: compose_files
+    )
+  end
 end

--- a/templates/docker_compose.erb
+++ b/templates/docker_compose.erb
@@ -1,0 +1,3 @@
+#!/bin/bash
+cd <%= @directory %>
+docker compose -p <%= @project %> -f <%= @config_files.join(' -f ') %> $@

--- a/test/integration/synapse/inspec/synapse_spec.rb
+++ b/test/integration/synapse/inspec/synapse_spec.rb
@@ -174,3 +174,15 @@ describe docker_container('e5af17-mjolnir-db-1') do
   it { should be_running }
   its('image') { should eq 'postgres' }
 end
+
+describe command '/opt/synapse-chat.example.org/bin/docker_compose ps' do
+  %w(
+    heisenbridge
+    hookshot
+    matrix-appservice-irc
+    mjolnir
+    synapse
+  ).each do |s|
+    its('stdout') { should match s }
+  end
+end


### PR DESCRIPTION
Since we manage so many different docker-compose files, it's rather difficult to
interact with the containers easily once deployed. This provides a simple helper
script that can be used to send commands to docker compose without needing to
worry about all of the configs that are needed.

Signed-off-by: Lance Albertson <lance@osuosl.org>
